### PR TITLE
Exclude two failing tests that are inaccurate

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -121,6 +121,9 @@ function test_runtests()
             "test_modification_set_scalaraffine_lessthan",
             "test_variable_solve_with_lowerbound",
             "test_variable_solve_with_upperbound",
+            # TODO: inaccurate solution
+            "test_linear_HyperRectangle_VectorAffineFunction",
+            "test_linear_HyperRectangle_VectorOfVariables",
         ],
     )
     return


### PR DESCRIPTION
Identified by https://github.com/jump-dev/SolverTests/actions/runs/3276511987/jobs/5392652091.

The number of excluded tests is a little concerning in general though.