### PR TITLE
Exclude test failing with change in MOI

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -154,6 +154,7 @@ function test_runtests()
             r"test_conic_SecondOrderCone_nonnegative_initial_bound$",
             r"test_quadratic_constraint_integration$",
             r"test_linear_variable_open_intervals$",
+            r"test_conic_SecondOrderCone_out_of_order$",
         ],
     )
     return


### PR DESCRIPTION
It will fail with this change in MOI https://github.com/jump-dev/MathOptInterface.jl/pull/2495 but the failure seems to be due to DSDP not converging even though the problem is equivalent.